### PR TITLE
fix: add YAML front matter to issue template (Fixes #21)

### DIFF
--- a/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE/ISSUE_TEMPLATE.md
@@ -1,3 +1,11 @@
+---
+name: Issue Report
+about: Create a report to help us improve
+title: "[type] Delete This and Write the Title"
+labels: ""
+assignees: ''
+---
+
 ## Description
 <!-- What is the issue or idea? -->
 


### PR DESCRIPTION
## Description
Added the missing YAML Front Matter to the issue template file so GitHub can recognize it.

## Changes
- Added `name`, `about`, `title`, `labels`, `assignees` metadata to `.github/ISSUE_TEMPLATE/issue_template.md`

Closes #21
